### PR TITLE
Added autoUpdate functionality

### DIFF
--- a/src/starling/extensions/pixelmask/PixelMaskDisplayObject.as
+++ b/src/starling/extensions/pixelmask/PixelMaskDisplayObject.as
@@ -28,13 +28,13 @@ package starling.extensions.pixelmask
 		private var _inverted:Boolean = false;
 		private var _scaleFactor:Number;
 		private var _isAnimated:Boolean = true;
-		private var _autoUpdate:Boolean = true;
+		private var _autoUpdate:Boolean = false;
 		private var _maskRendered:Boolean = false;
 		
 		public function PixelMaskDisplayObject(
 			scaleFactor:Number=-1, 
 			isAnimated:Boolean=true, 
-			autoUpdate:Boolean=true
+			autoUpdate:Boolean=false
 		)
 		{
 			super();			


### PR DESCRIPTION
When autoUpdate is enabled, the mask will be re-applied anytime the display list changes. It is off by default for backwards-compatibility. autoUpdate works by overridding methods such as addChild and removeChild. This means that if someone was to repeatedly call those methods (in a loop for example) there would be a performance impact.

I decided to add the autoUpdate param in the constructor. I think it makes sense but I'll let you decide. Cheers!
